### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/app/api/metadata/gitcoin/[address]/route.ts
+++ b/app/api/metadata/gitcoin/[address]/route.ts
@@ -53,7 +53,13 @@ function createResponse(score: number, stamps: any[]): StampResponse {
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const address = req.nextUrl.searchParams.get("address");
 
-  if (!address || !isValidEthereumAddress(address)) {
+  // Extra defense: ensure address strictly matches Ethereum address format.
+  const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+  if (
+    !address ||
+    !isValidEthereumAddress(address) ||
+    !ETH_ADDRESS_REGEX.test(address)
+  ) {
     return NextResponse.json(createResponse(0, []));
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/web3.bio.app/security/code-scanning/7](https://github.com/Dargon789/web3.bio.app/security/code-scanning/7)

To fix this SSRF risk, further restrict the format of the incoming `address` parameter before it is used to construct a URL. This builds defense-in-depth in case of future changes to `isValidEthereumAddress()` or bugs. Specifically, ensure that the `address` strictly matches the pattern for valid Ethereum addresses (`/^0x[a-fA-F0-9]{40}$/`). Add an explicit regular expression check where the input is first received (line 56), rejecting any address that fails this match. 
- Only change code inside the shown file.
- If `isValidEthereumAddress` is already a robust regex, reinforce by adding an explicit check or comment.
- No need to change the endpoint host (remains constant).
- If already safe, add the regex check as a fallback.

**What is needed:** Add a regex definition or check for Ethereum addresses after obtaining `address`, before using it in further processing. If not matching, return an empty response as before. Do not change existing logic, only supplement input validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add explicit ETH_ADDRESS_REGEX check alongside isValidEthereumAddress to reject malformed addresses